### PR TITLE
Remove cookie warning overlay from DOM before taking screenshot

### DIFF
--- a/1-testing/3-quick-recipes/intercept-request.js
+++ b/1-testing/3-quick-recipes/intercept-request.js
@@ -23,6 +23,10 @@ page.on('request', async request => {
 
 await page.setViewport({ width: 1280, height: 800 })
 await page.goto('https://www.sainsburys.co.uk/gol-ui/product/vita-coco-coconut-oil-500ml')
+await page.evaluate(() => {
+	let cookieOverlay = document.querySelector('.onetrust-pc-dark-filter');
+	cookieOverlay.parentNode.removeChild(cookieOverlay);
+});
 await page.screenshot({ path: screenshotPath, fullPage: true })
 
 await browser.close();


### PR DESCRIPTION
This removes the dark overlay from the page that is caused by the "accept cookie" prompt before taking a screenshot.