### PR TITLE
ci: cache NPM caching dir instead of node_modules

### DIFF
--- a/.github/workflows/4-deploying-ava.yaml
+++ b/.github/workflows/4-deploying-ava.yaml
@@ -1,8 +1,15 @@
 name: Runs ava tests (module 4)
 on:
   push:
+    branches: [ master ]
     paths:
     - '4-deploying/1-github-actions/ava/**'
+    - '.github/workflows/4-deploying-ava.yaml'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '4-deploying/1-github-actions/ava/**'
+    - '.github/workflows/4-deploying-ava.yaml'
 jobs:
   ava:
     name: Execute ava
@@ -17,18 +24,14 @@ jobs:
           node-version: '*'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
 
-      - name: npm install
-        run: |
-          npm install
+      - name: npm ci
+        run: npm ci
 
       - name: run tests with ava
         run: |

--- a/.github/workflows/4-deploying-cypress.yaml
+++ b/.github/workflows/4-deploying-cypress.yaml
@@ -1,8 +1,15 @@
 name: Runs cypress tests (module 4)
 on:
   push:
+    branches: [ master ]
     paths:
     - '4-deploying/1-github-actions/cypress/**'
+    - '.github/workflows/4-deploying-cypress.yaml'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '4-deploying/1-github-actions/cypress/**'
+    - '.github/workflows/4-deploying-cypress.yaml'
 jobs:
   cypress:
     name: Execute cypress
@@ -17,18 +24,14 @@ jobs:
           node-version: '*'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
 
-      - name: npm install
-        run: |
-          npm install && npm install cypress && ./node_modules/.bin/cypress install
+      - name: npm ci
+        run: npm ci
 
       - name: run cypress tests
         run: npm run --silent --prefix 4-deploying/1-github-actions/cypress start

--- a/.github/workflows/4-deploying-jest.yaml
+++ b/.github/workflows/4-deploying-jest.yaml
@@ -1,8 +1,15 @@
 name: Runs jest tests (module 4)
 on:
   push:
+    branches: [ master ]
     paths:
     - '4-deploying/1-github-actions/jest/**'
+    - '.github/workflows/4-deploying-jest.yaml'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '4-deploying/1-github-actions/jest/**'
+    - '.github/workflows/4-deploying-jest.yaml'
 jobs:
   jest:
     name: Execute jest
@@ -17,18 +24,14 @@ jobs:
           node-version: '*'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
 
-      - name: npm install
-        run: |
-          npm install
+      - name: npm ci
+        run: npm ci
 
       - name: runs tests with jest
         run: npm run --silent --prefix 4-deploying/1-github-actions/jest start

--- a/.github/workflows/4-deploying-puppeteer.yaml
+++ b/.github/workflows/4-deploying-puppeteer.yaml
@@ -1,8 +1,15 @@
 name: Runs puppeteer tests (module 4)
 on:
   push:
+    branches: [ master ]
     paths:
     - '4-deploying/1-github-actions/puppeteer/**'
+    - '.github/workflows/4-deploying-puppeteer.yaml'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '4-deploying/1-github-actions/puppeteer/**'
+    - '.github/workflows/4-deploying-puppeteer.yaml'
 jobs:
   pptr:
     name: Execute puppeteer
@@ -17,18 +24,14 @@ jobs:
           node-version: '*'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
 
-      - name: npm install
-        run: |
-          npm install
+      - name: npm ci
+        run: npm ci
 
       - name: run puppeteer tests
         run: |

--- a/.github/workflows/4-deploying-testcafe.yaml
+++ b/.github/workflows/4-deploying-testcafe.yaml
@@ -1,8 +1,15 @@
 name: Runs testcafe tests (module 4)
 on:
   push:
+    branches: [ master ]
     paths:
     - '4-deploying/1-github-actions/testcafe/**'
+    - '.github/workflows/4-deploying-testcafe.yaml'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '4-deploying/1-github-actions/testcafe/**'
+    - '.github/workflows/4-deploying-testcafe.yaml'
 jobs:
   testcafe:
     name: Execute testcafe
@@ -17,18 +24,14 @@ jobs:
           node-version: '*'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
 
-      - name: npm install
-        run: |
-          npm install
+      - name: npm ci
+        run: npm ci
 
       - name: runs testcafe tests
         run: |

--- a/.github/workflows/4-deploying-trace-and-har.yaml
+++ b/.github/workflows/4-deploying-trace-and-har.yaml
@@ -1,8 +1,15 @@
 name: Runs the 5-trace-and-har module
 on:
   push:
+    branches: [ master ]
     paths:
     - '4-deploying/5-trace-and-har/**'
+    - '.github/workflows/4-deploying-trace-and-har.yaml'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '4-deploying/5-trace-and-har/**'
+    - '.github/workflows/4-deploying-trace-and-har.yaml'
 jobs:
   pptr:
     name: Execute puppeteer
@@ -17,18 +24,14 @@ jobs:
           node-version: '*'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
 
-      - name: npm install
-        run: |
-          npm install && npm install playwright
+      - name: npm ci
+        run: npm ci
 
       - name: run tests
         run: |

--- a/.github/workflows/4-deploying-videos-screenshots.yaml
+++ b/.github/workflows/4-deploying-videos-screenshots.yaml
@@ -1,8 +1,15 @@
 name: Runs the 4-videos-screenshots module
 on:
   push:
+    branches: [ master ]
     paths:
     - '4-deploying/4-videos-screenshots/**'
+    - '.github/workflows/4-deploying-videos-screenshots.yaml'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '4-deploying/4-videos-screenshots/**'
+    - '.github/workflows/4-deploying-videos-screenshots.yaml'
 jobs:
   pptr:
     name: Execute playwright with videos and screenshots
@@ -17,18 +24,14 @@ jobs:
           node-version: '*'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
 
-      - name: npm install
-        run: |
-          npm install && npm install playwright
+      - name: npm ci
+        run: npm ci
 
       - name: run tests
         run: |

--- a/.github/workflows/4-deploying-videos-simple.yaml
+++ b/.github/workflows/4-deploying-videos-simple.yaml
@@ -1,8 +1,15 @@
 name: Runs the 3-videos-simple module
 on:
   push:
+    branches: [ master ]
     paths:
     - '4-deploying/3-videos-simple/**'
+    - '.github/workflows/4-deploying-videos-simple.yaml'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '4-deploying/3-videos-simple/**'
+    - '.github/workflows/4-deploying-videos-simple.yaml'
 jobs:
   pptr:
     name: Execute playwright
@@ -17,18 +24,14 @@ jobs:
           node-version: '*'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
 
-      - name: npm install
-        run: |
-          npm install && npm install playwright
+      - name: npm ci
+        run: npm ci
 
       - name: run tests
         run: |

--- a/.github/workflows/lighthouse-ci.yaml
+++ b/.github/workflows/lighthouse-ci.yaml
@@ -1,8 +1,15 @@
 name: Run Lighthouse CI
 on:
   push:
+    branches: [ master ]
     paths:
     - '3-auditing/1-lighthouse/**'
+    - '.github/workflows/lighthouse-ci.yaml'
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '3-auditing/1-lighthouse/**'
+    - '.github/workflows/lighthouse-ci.yaml'
 jobs:
   lhci:
     name: Lighthouse CI
@@ -17,18 +24,14 @@ jobs:
           node-version: '*'
 
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
 
-      - name: npm install
-        run: |
-          npm install
+      - name: npm ci
+        run: npm ci
 
       - name: run Lighthouse CI
         env:


### PR DESCRIPTION
Hi Umar,

related to that (https://github.com/microsoft/playwright/issues/3712) issue I followed up with adjusting your caching strategy with GitHub Actions.

I updated the caching action to v2 and cache instead of node_modules the NPM cache directory which is recommend see [here](https://github.com/actions/cache/blob/main/examples.md#node---npm). Caching the node_modules folder can lead to the behaviour which you've experienced that you need to install Cypress or Playwright manually again with npm install.

Also I switched to `npm ci` instead of `npm install` which is optimised to run on bots. This will strictly use the package-lock.json and always install the pinned version. ([Test run](https://github.com/mxschmitt/github-actions-caching-issue-test/runs/1075498780?check_suite_focus=true#step:4:7)). Also using now pull request triggers too so external contributors will trigger the bots.

The failing bots seem unrelated.